### PR TITLE
lerna-app-library 2.0.0-80f86b49-SNAPSHOT に更新する

### DIFF
--- a/src/main/g8/CHANGELOG.md
+++ b/src/main/g8/CHANGELOG.md
@@ -6,6 +6,11 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 
 ## Unreleased
 
-## Version 0.0.0
+- lerna-app-library 2.0.0-80f86b49-SNAPSHOT に更新しました
+- scalatest 3.1.4 に更新しました
+- akka-http 10.2.4 に更新しました
+- akka-cluster の代わりに akka-cluster-typed を使用するようにしました
+
+## Version 1.0.0
 
 - Initial release

--- a/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
+++ b/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
@@ -5,7 +5,6 @@ import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.server.Route
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import lerna.log.AppLogging
 import lerna.util.time.JavaDurationConverters._
@@ -30,9 +29,7 @@ class MyApp(implicit
     startServer("management", rootRoute.managementRoute, managementInterface, managementPort)
   }
 
-  private[this] def startServer(typeName: String, route: Route, interface: String, port: Int)(implicit
-      fm: Materializer,
-  ): Unit = {
+  private[this] def startServer(typeName: String, route: Route, interface: String, port: Int): Unit = {
     Http()
       .newServerAt(interface, port)
       .bindFlow(route)

--- a/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
+++ b/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
@@ -34,7 +34,8 @@ class MyApp(implicit
       fm: Materializer,
   ): Unit = {
     Http()
-      .bindAndHandle(route, interface, port)
+      .newServerAt(interface, port)
+      .bindFlow(route)
       .foreach { serverBinding =>
         addToShutdownHook(typeName, serverBinding)
       }

--- a/src/main/g8/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
+++ b/src/main/g8/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
@@ -1,7 +1,7 @@
 package myapp.utility.scalatest
 
-import org.scalatest.MustMatchers
 import lerna.util.lang.Equals
+import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-trait StandardSpec extends AnyWordSpecLike with SpecAssertions with Equals with MustMatchers
+trait StandardSpec extends AnyWordSpecLike with SpecAssertions with Equals with Matchers

--- a/src/main/g8/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
+++ b/src/main/g8/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
@@ -1,6 +1,7 @@
 package myapp.utility.scalatest
 
-import org.scalatest.{ MustMatchers, WordSpecLike }
+import org.scalatest.MustMatchers
 import lerna.util.lang.Equals
+import org.scalatest.wordspec.AnyWordSpecLike
 
-trait StandardSpec extends WordSpecLike with SpecAssertions with Equals with MustMatchers
+trait StandardSpec extends AnyWordSpecLike with SpecAssertions with Equals with MustMatchers

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -36,6 +36,9 @@ ThisBuild / fork in Test := true
 // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき紛らわしいため
 ThisBuild / outputStrategy := Some(StdoutOutput)
 
+// TODO SNAPSHOT を使用しなくなったら SNAPSHOT用の resolver は削除すること
+ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
+
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, JavaServerAppPackaging, RpmPlugin, SystemdPlugin)
   .aggregate(

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val lerna                    = "1.0.0"
+    val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
     val akka                     = "2.6.8"
     val akkaHttp                 = "10.1.12"
     val akkaPersistenceCassandra = "1.0.1"

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val slf4j            = "com.typesafe.akka" %% "akka-slf4j"              % Versions.akka
     val actor            = "com.typesafe.akka" %% "akka-actor"              % Versions.akka
     val stream           = "com.typesafe.akka" %% "akka-stream"             % Versions.akka
-    val cluster          = "com.typesafe.akka" %% "akka-cluster"            % Versions.akka
+    val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"      % Versions.akka
     val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"      % Versions.akka
     val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding"   % Versions.akka
     val persistence      = "com.typesafe.akka" %% "akka-persistence"        % Versions.akka

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val akka                     = "2.6.8"
     val akkaHttp                 = "10.1.12"
     val akkaPersistenceCassandra = "1.0.1"
-    val scalaTest                = "3.0.9"
+    val scalaTest                = "3.1.4"
     val airframe                 = "20.9.0"
     val logback                  = "1.2.3"
     val slick                    = "3.3.2"

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object Versions {
     val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
     val akka                     = "2.6.8"
-    val akkaHttp                 = "10.1.12"
+    val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"
     val scalaTest                = "3.1.4"
     val airframe                 = "20.9.0"


### PR DESCRIPTION
次の issue の対応をスムーズにするため、SNAPSHOT バージョンに更新します。
[lerna-app-library v2.0.0 を使うようにしたい · Issue #1 · lerna-stack/lerna.g8](https://github.com/lerna-stack/lerna.g8/settings)

## 動作確認
テストに加えて、念のため HTTP API が動作しているかを確認しました。

https://github.com/lerna-stack/lerna.g8/tree/1.x/src/main/g8#api

次の6つが動いていることを確認しました。
```
curl --silent --noproxy "*" http://127.0.0.1:9001/index
curl --silent --noproxy "*" http://127.0.0.1:9002/version
curl --silent --noproxy "*" http://127.0.0.1:9002/commit-hash
curl --silent --noproxy "*" http://127.0.0.2:9001/index
curl --silent --noproxy "*" http://127.0.0.2:9002/version
curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
```