### PR TITLE
sbt-wartremover-2.4.13 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update *lerna-app-library* to 2.0.0-80f86b49-SNAPSHOT
 - Update *scalatest* to 3.1.4
 - Update *akka-http* to 10.2.4
+- Update *sbt-wartremover* to 2.4.13
 - Use *akka-cluter-typed* instead of *akka-cluster*
 
 ## 1.x

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"            % "2.4.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager"     % "1.3.22")
 addSbtPlugin("org.duhemm"       % "sbt-errors-summary"      % "0.6.3")
-addSbtPlugin("org.wartremover"  % "sbt-wartremover"         % "2.4.10")
+addSbtPlugin("org.wartremover"  % "sbt-wartremover"         % "2.4.13")
 addSbtPlugin("org.wartremover"  % "sbt-wartremover-contrib" % "1.3.1")
 addSbtPlugin("org.scoverage"    % "sbt-scoverage"           % "1.5.1")


### PR DESCRIPTION
Scala 2.13.4 を利用するために、sbt-wartremover を 2.4.13 に更新します。
sbt-wartremover 2.4.10 は Scala 2.13.4 に対応していません。

次の PR にて実施した対応と同じ内容です。
[sbt-wartremover を 2.4.13 に更新する by xirc · Pull Request #17 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/pull/17)
