### PR TITLE
CHANGELOG の内容を適切な場所に移動する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## Unreleased
+### Changed
+- Update *lerna-app-library* to 2.0.0-80f86b49-SNAPSHOT
+- Update *scalatest* to 3.1.4
+- Update *akka-http* to 10.2.4
+- Use *akka-cluter-typed* instead of *akka-cluster*
+
+## 1.x
+- Initial release

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ If you want to change something about the template,
 you can open `src/main/g8` as an *sbt* project in your favorite editor.
 It will be recognized as a general *sbt* project.
 
+## Changelog
+
+You can see all the notable changes in [CHANGELOG](CHANGELOG.md).
+
 ## How to test the template
 
 Run `sbt test`.

--- a/src/main/g8/CHANGELOG.md
+++ b/src/main/g8/CHANGELOG.md
@@ -6,11 +6,6 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 
 ## Unreleased
 
-- lerna-app-library 2.0.0-80f86b49-SNAPSHOT に更新しました
-- scalatest 3.1.4 に更新しました
-- akka-http 10.2.4 に更新しました
-- akka-cluster の代わりに akka-cluster-typed を使用するようにしました
-
-## Version 1.0.0
+## Version 0.0.0
 
 - Initial release


### PR DESCRIPTION
変更点を `sbt new ...` でコピーされるプロジェクト内に誤って配置してありました。
より適切な場所に変更点を記載するようにします。
それにあわせて、ほかのドキュメントが英語になっているため、記述を英語に変更しました。