### PR TITLE
Update Scala to 2.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update *Scala* to 2.13.4
 - Update *lerna-app-library* to 2.0.0-80f86b49-SNAPSHOT
 - Update *scalatest* to 3.1.4
 - Update *akka-http* to 10.2.4

--- a/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
+++ b/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
@@ -44,7 +44,7 @@ class MyApp(implicit
     val coordinatedShutdown = CoordinatedShutdown(actorSystem)
 
     coordinatedShutdown.addTask(CoordinatedShutdown.PhaseServiceUnbind, s"http-unbind-$typeName") { () =>
-      logger.info(s"[$typeName] 終了処理のため、$serverBinding をunbindします")
+      logger.info(s"[$typeName] 終了処理のため、${serverBinding.toString} をunbindします")
 
       serverBinding.unbind().map(_ => Done)
     }
@@ -54,10 +54,10 @@ class MyApp(implicit
         val hardDeadline =
           config.getDuration("myapp.entrypoint.graceful-termination.hard-deadline").asScala
 
-        logger.info(s"[$typeName] 終了処理のため、$serverBinding の graceful terminate を開始します（最大で $hardDeadline 待ちます）")
+        logger.info(s"[$typeName] 終了処理のため、${serverBinding.toString} の graceful terminate を開始します（最大で ${hardDeadline.toString} 待ちます）")
 
         serverBinding.terminate(hardDeadline) map { _ =>
-          logger.info(s"[$typeName] 終了処理のための $serverBinding の graceful terminate が終了しました")
+          logger.info(s"[$typeName] 終了処理のための ${serverBinding.toString} の graceful terminate が終了しました")
 
           Done
         }

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / name := "myapp"
 ThisBuild / description := "description"
 ThisBuild / version := "1.0.0"
 ThisBuild / organization := "organization"
-ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / scalaVersion := "2.13.4"
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation",
   "-feature",

--- a/src/main/g8/slick-codegen/src/main/scala/Codegen.scala
+++ b/src/main/g8/slick-codegen/src/main/scala/Codegen.scala
@@ -23,7 +23,7 @@ object Codegen extends App {
 
   val config                         = ConfigFactory.load().getConfig("slick.codegen")
   val dbConfig                       = DatabaseConfig.forConfig[JdbcProfile]("", config)
-  val excludeTableNames: Seq[String] = config.getStringList("excludeTableNames").asScala
+  val excludeTableNames: Seq[String] = config.getStringList("excludeTableNames").asScala.toSeq
   import dbConfig._
 
   val tables = profile.defaultTables.map(_.filterNot { table =>

--- a/src/main/g8/slick-codegen/src/main/scala/Codegen.scala
+++ b/src/main/g8/slick-codegen/src/main/scala/Codegen.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 @SuppressWarnings(
   Array(


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna.g8/issues/2

Scala 2.13.4 に更新します。

## リリースノート

Scala 2.12.12 => Scala 2.13.4 までのリリースノートは次のページから確認できます。
- [Release Scala 2.13.0 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.0)
- [Release Scala 2.13.1 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.1)
- [Release Scala 2.13.2 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.2)
- [Release Scala 2.13.3 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.3)
- [Release Scala 2.13.4 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.4)

## マイグレーション

いくつかのマイグレーションを実施しました。
- wartremover:StringPlusAny の警告を解決する
- コンパイルエラーと非推奨警告を修正する
  [Collections Redesign | Release Scala 2.13.0 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.0#:~:text=Collections%20redesign) によるものです。

## 動作確認
ユニットテスト以外に、README に記載の次の内容を動作確認しました。
- HTTP API が動作していること 
  ```
  curl --silent --noproxy "*" http://127.0.0.1:9001/index
  curl --silent --noproxy "*" http://127.0.0.1:9002/version
  curl --silent --noproxy "*" http://127.0.0.1:9002/commit-hash
  curl --silent --noproxy "*" http://127.0.0.2:9001/index
  curl --silent --noproxy "*" http://127.0.0.2:9002/version
  curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
  ```
- テストカバレッジが取得できること
  `sbt take-test-coverage`
- Slick コード生成が動作すること
  `sbt slick-codegen/run`
- RPM パッケージをビルドできること
  `docker-compose run --rm sbt-rpmbuild clean rpm:packageBin`
  このコマンドは `sbt new file://lerna.g8 --name=lerna-example` してできたプロジェクトを、
   git にチェックインした後に実行する必要があります。