### PR TITLE
Akka 2.6.12 に更新する

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -195,6 +195,7 @@ lazy val `testkit` = (project in file("app/testkit"))
   .settings(
     name := "testkit",
     libraryDependencies ++= Seq(
+      Akka.actor,
       Lerna.util,
       Lerna.testkit,
       Expecty.expecty,

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
-    val akka                     = "2.6.8"
+    val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"
     val scalaTest                = "3.1.4"

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
 
   object Akka {
     val slf4j            = "com.typesafe.akka" %% "akka-slf4j"              % Versions.akka
-    val actor            = "com.typesafe.akka" %% "akka-actor"              % Versions.akka
+    val actor            = "com.typesafe.akka" %% "akka-actor-typed"        % Versions.akka
     val stream           = "com.typesafe.akka" %% "akka-stream"             % Versions.akka
     val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"      % Versions.akka
     val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"      % Versions.akka


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna.g8/issues/14

## リリースノート
即座に対応が必要そうなマイグレーションはなさそうに思います。
- [Akka 2.6.9 Released | Akka](https://akka.io/blog/news/2020/09/09/akka-2.6.9-released)
- [Akka 2.6.10 Released | Akka](https://akka.io/blog/news/2020/10/09/akka-2.6.10-released)
- [Akka 2.6.11 Released | Akka](https://akka.io/blog/news/2021/01/15/akka-2.6.11-released)
- [Akka 2.6.12 Released | Akka](https://akka.io/blog/news/2021/01/28/akka-2.6.12-released)

## Akka のパッチバージョン統一

Akka のパッチバージョンをプロジェクト全体で統一する必要があります。
依存している Akka のバージョンが 2.6.12 に統一されていることを次のように確認できます。
```
$ cd src/main/g8
$ sbt dependencyList | grep akka | sort | uniq
[info] com.lerna-stack:lerna-util-akka_2.13:2.0.0-80f86b49-SNAPSHOT
[info] com.lightbend.akka:akka-stream-alpakka-cassandra_2.13:2.0.1
[info] com.typesafe.akka:akka-actor_2.13:2.6.12
[info] com.typesafe.akka:akka-actor-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-sharding_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-tools_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-coordination_2.13:2.6.12
[info] com.typesafe.akka:akka-distributed-data_2.13:2.6.12
[info] com.typesafe.akka:akka-http_2.13:10.2.4
[info] com.typesafe.akka:akka-http-core_2.13:10.2.4
[info] com.typesafe.akka:akka-http-spray-json_2.13:10.2.4
[info] com.typesafe.akka:akka-parsing_2.13:10.2.4
[info] com.typesafe.akka:akka-persistence_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence-cassandra_2.13:1.0.1
[info] com.typesafe.akka:akka-persistence-query_2.13:2.6.12
[info] com.typesafe.akka:akka-pki_2.13:2.6.12
[info] com.typesafe.akka:akka-protobuf-v3_2.13:2.6.12
[info] com.typesafe.akka:akka-remote_2.13:2.6.12
[info] com.typesafe.akka:akka-slf4j_2.13:2.6.12
[info] com.typesafe.akka:akka-stream_2.13:2.6.12
[info] io.altoo:akka-kryo-serialization_2.13:1.1.5
```

## 動作確認

ユニットテストに加えて、HTTP API が動作しているかを確認しました。
```
curl --silent --noproxy "*" http://127.0.0.1:9001/index
curl --silent --noproxy "*" http://127.0.0.1:9002/version
curl --silent --noproxy "*" http://127.0.0.1:9002/commit-hash
curl --silent --noproxy "*" http://127.0.0.2:9001/index
curl --silent --noproxy "*" http://127.0.0.2:9002/version
curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
```