### PR TITLE
Akka Typed を使用する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+#### Dependency updates
 - Update *Scala* to 2.13.4
 - Add *akka-entity-replication* 1.0.0+157-482a23b1-SNAPSHOT
 - Update *lerna-app-library* to 2.0.0-80f86b49-SNAPSHOT
@@ -13,7 +14,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update *akka-http* to 10.2.4
 - Update *sbt-wartremover* to 2.4.13
 - Update *sbt-scoverage* to 1.8.2
-- Use *akka-cluter-typed* instead of *akka-cluster*
+#### Use Akka Typed instead of Akka Classic
+- Use *akka-actor-typed* instead of *akka-actor*
+- Use *akka-cluster-typed* instead of *akka-cluster*
+- Use *akka-cluster-sharding-typed* instead of *akka-cluster-sharding*
+- Use *akka-persistence-typed* instead of *akka-persistence*
+- Remove the direct dependency *akka-slf4j*  
+    We don't need to specify the dependency since we use *akka-actor-typed* instead.
+- Add *akka-persistence-testkit*  
+    It would be great to test `EventSourcedBehavior`s
 
 ## 1.x
 - Initial release

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -72,7 +72,7 @@ lazy val `presentation` = (project in file("app/presentation"))
       Akka.stream,
       AkkaHttp.http,
       AkkaHttp.sprayJson,
-      Akka.testKit         % Test,
+      Akka.actorTestKit    % Test,
       AkkaHttp.httpTestKit % Test,
     ),
   )
@@ -92,7 +92,7 @@ lazy val `gateway` = (project in file("app/gateway"))
       Akka.stream,
       AkkaHttp.http,
       AkkaHttp.sprayJson,
-      Akka.testKit         % Test,
+      Akka.actorTestKit    % Test,
       AkkaHttp.httpTestKit % Test,
     ),
   )
@@ -132,7 +132,7 @@ lazy val `application` = (project in file("app/application"))
       AkkaPersistenceCassandra.akkaPersistenceCassandra,
       Kryo.kryo,
       SprayJson.sprayJson,
-      Akka.testKit          % Test,
+      Akka.actorTestKit     % Test,
       Akka.multiNodeTestKit % Test,
       Akka.streamTestKit    % Test,
     ),

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -132,9 +132,10 @@ lazy val `application` = (project in file("app/application"))
       AkkaPersistenceCassandra.akkaPersistenceCassandra,
       Kryo.kryo,
       SprayJson.sprayJson,
-      Akka.actorTestKit     % Test,
-      Akka.multiNodeTestKit % Test,
-      Akka.streamTestKit    % Test,
+      Akka.actorTestKit       % Test,
+      Akka.multiNodeTestKit   % Test,
+      Akka.streamTestKit      % Test,
+      Akka.persistenceTestKit % Test,
     ),
   )
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -129,7 +129,6 @@ lazy val `application` = (project in file("app/application"))
       Akka.cluster,
       Akka.clusterTools,
       Akka.clusterSharding,
-      Akka.slf4j,
       Akka.persistenceQuery,
       AkkaPersistenceCassandra.akkaPersistenceCassandra,
       Kryo.kryo,

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -128,6 +128,7 @@ lazy val `application` = (project in file("app/application"))
       Akka.persistence,
       Akka.cluster,
       Akka.clusterSharding,
+      Akka.clusterTools,
       Akka.persistenceQuery,
       AkkaPersistenceCassandra.akkaPersistenceCassandra,
       Kryo.kryo,

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -127,7 +127,6 @@ lazy val `application` = (project in file("app/application"))
       Akka.stream,
       Akka.persistence,
       Akka.cluster,
-      Akka.clusterTools,
       Akka.clusterSharding,
       Akka.persistenceQuery,
       AkkaPersistenceCassandra.akkaPersistenceCassandra,

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -38,6 +38,7 @@ object Dependencies {
     val stream             = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
     val cluster            = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
     val clusterSharding    = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
+    val clusterTools       = "com.typesafe.akka" %% "akka-cluster-tools"          % Versions.akka
     val persistence        = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
     val persistenceQuery   = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
     val actorTestKit       = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -34,15 +34,16 @@ object Dependencies {
   }
 
   object Akka {
-    val actor            = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
-    val stream           = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
-    val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
-    val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
-    val persistence      = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
-    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
-    val actorTestKit     = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
-    val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
-    val multiNodeTestKit = "com.typesafe.akka" %% "akka-multi-node-testkit"     % Versions.akka
+    val actor              = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
+    val stream             = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
+    val cluster            = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
+    val clusterSharding    = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
+    val persistence        = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
+    val persistenceQuery   = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
+    val actorTestKit       = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
+    val streamTestKit      = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
+    val multiNodeTestKit   = "com.typesafe.akka" %% "akka-multi-node-testkit"     % Versions.akka
+    val persistenceTestKit = "com.typesafe.akka" %% "akka-persistence-testkit"    % Versions.akka
   }
 
   object AkkaHttp {

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -34,16 +34,16 @@ object Dependencies {
   }
 
   object Akka {
-    val actor            = "com.typesafe.akka" %% "akka-actor-typed"         % Versions.akka
-    val stream           = "com.typesafe.akka" %% "akka-stream"              % Versions.akka
-    val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"       % Versions.akka
-    val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"       % Versions.akka
-    val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding"    % Versions.akka
-    val persistence      = "com.typesafe.akka" %% "akka-persistence"         % Versions.akka
-    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"   % Versions.akka
-    val testKit          = "com.typesafe.akka" %% "akka-actor-testkit-typed" % Versions.akka
-    val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"      % Versions.akka
-    val multiNodeTestKit = "com.typesafe.akka" %% "akka-multi-node-testkit"  % Versions.akka
+    val actor            = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
+    val stream           = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
+    val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
+    val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"          % Versions.akka
+    val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
+    val persistence      = "com.typesafe.akka" %% "akka-persistence"            % Versions.akka
+    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
+    val testKit          = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
+    val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
+    val multiNodeTestKit = "com.typesafe.akka" %% "akka-multi-node-testkit"     % Versions.akka
   }
 
   object AkkaHttp {

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     val stream           = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
     val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
     val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
-    val persistence      = "com.typesafe.akka" %% "akka-persistence"            % Versions.akka
+    val persistence      = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
     val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
     val testKit          = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
     val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -34,17 +34,17 @@ object Dependencies {
   }
 
   object Akka {
-    val slf4j            = "com.typesafe.akka" %% "akka-slf4j"              % Versions.akka
-    val actor            = "com.typesafe.akka" %% "akka-actor-typed"        % Versions.akka
-    val stream           = "com.typesafe.akka" %% "akka-stream"             % Versions.akka
-    val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"      % Versions.akka
-    val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"      % Versions.akka
-    val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding"   % Versions.akka
-    val persistence      = "com.typesafe.akka" %% "akka-persistence"        % Versions.akka
-    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"  % Versions.akka
-    val testKit          = "com.typesafe.akka" %% "akka-testkit"            % Versions.akka
-    val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"     % Versions.akka
-    val multiNodeTestKit = "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.akka
+    val slf4j            = "com.typesafe.akka" %% "akka-slf4j"               % Versions.akka
+    val actor            = "com.typesafe.akka" %% "akka-actor-typed"         % Versions.akka
+    val stream           = "com.typesafe.akka" %% "akka-stream"              % Versions.akka
+    val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"       % Versions.akka
+    val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"       % Versions.akka
+    val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding"    % Versions.akka
+    val persistence      = "com.typesafe.akka" %% "akka-persistence"         % Versions.akka
+    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"   % Versions.akka
+    val testKit          = "com.typesafe.akka" %% "akka-actor-testkit-typed" % Versions.akka
+    val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"      % Versions.akka
+    val multiNodeTestKit = "com.typesafe.akka" %% "akka-multi-node-testkit"  % Versions.akka
   }
 
   object AkkaHttp {

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -34,7 +34,6 @@ object Dependencies {
   }
 
   object Akka {
-    val slf4j            = "com.typesafe.akka" %% "akka-slf4j"               % Versions.akka
     val actor            = "com.typesafe.akka" %% "akka-actor-typed"         % Versions.akka
     val stream           = "com.typesafe.akka" %% "akka-stream"              % Versions.akka
     val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"       % Versions.akka

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
     val persistence      = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
     val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
-    val testKit          = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
+    val actorTestKit     = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
     val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
     val multiNodeTestKit = "com.typesafe.akka" %% "akka-multi-node-testkit"     % Versions.akka
   }

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -37,7 +37,6 @@ object Dependencies {
     val actor            = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
     val stream           = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
     val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
-    val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"          % Versions.akka
     val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
     val persistence      = "com.typesafe.akka" %% "akka-persistence"            % Versions.akka
     val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna.g8/issues/7

依存ライブラリを Akka Classic から Akka Typed に変更します。
Akka Classic から Akka Typed に変更したものは コミットログから確認できます。

### 変更していないライブラリ

#### `akka-multi-node-testkit`
[Multi Node Testing • Akka Documentation](https://doc.akka.io/docs/akka/current/multi-node-testing.html#module-info)
引き続き同じ依存ライブラリを使用できます。

#### `akka-stream`, `akka-stream-testkit`
[Streams • Akka Documentation](https://doc.akka.io/docs/akka/current/stream/index.html#module-info)
Typed 版もありますが、Typed Actor の API を使用したい場合にユーザが変更する方針で良さそうに思います。

#### `akka-persistence-query`
[Persistence Query • Akka Documentation](https://doc.akka.io/docs/akka/current/persistence-query.html#dependency)
引き続き同じ依存ライブラリを使用できます。

## Akka のバージョンが統一されているか？
次のコマンドで確認できます。

```
$ sbt dependencyList | grep akka | sort | uniq
[info] com.lerna-stack:akka-entity-replication_2.13:1.0.0+157-482a23b1-SNAPSHOT
[info] com.lerna-stack:lerna-util-akka_2.13:2.0.0-80f86b49-SNAPSHOT
[info] com.lightbend.akka:akka-stream-alpakka-cassandra_2.13:2.0.1
[info] com.typesafe.akka:akka-actor_2.13:2.6.12
[info] com.typesafe.akka:akka-actor-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-sharding_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-sharding-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-tools_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-coordination_2.13:2.6.12
[info] com.typesafe.akka:akka-distributed-data_2.13:2.6.12
[info] com.typesafe.akka:akka-http_2.13:10.2.4
[info] com.typesafe.akka:akka-http-core_2.13:10.2.4
[info] com.typesafe.akka:akka-http-spray-json_2.13:10.2.4
[info] com.typesafe.akka:akka-parsing_2.13:10.2.4
[info] com.typesafe.akka:akka-persistence_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence-cassandra_2.13:1.0.1
[info] com.typesafe.akka:akka-persistence-query_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-pki_2.13:2.6.12
[info] com.typesafe.akka:akka-protobuf-v3_2.13:2.6.12
[info] com.typesafe.akka:akka-remote_2.13:2.6.12
[info] com.typesafe.akka:akka-slf4j_2.13:2.6.12
[info] com.typesafe.akka:akka-stream_2.13:2.6.12
[info] com.typesafe.akka:akka-stream-typed_2.13:2.6.12
[info] io.altoo:akka-kryo-serialization_2.13:1.1.5
```

### 動作確認
HTTP API が動作していることを確認しました。
```
curl --silent --noproxy "*" http://127.0.0.1:9001/index
curl --silent --noproxy "*" http://127.0.0.1:9002/version
curl --silent --noproxy "*" http://127.0.0.1:9002/commit-hash
curl --silent --noproxy "*" http://127.0.0.2:9001/index
curl --silent --noproxy "*" http://127.0.0.2:9002/version
curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
```