### PR TITLE
akka-kryo-serialization-typed 2.1.0 を使用する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+
 #### Dependency updates
 - Update *Scala* to 2.13.4
 - Add *akka-entity-replication* 1.0.0+157-482a23b1-SNAPSHOT
@@ -12,8 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update *scalatest* to 3.1.4
 - Update *akka* to 2.6.12
 - Update *akka-http* to 10.2.4
+- Add *akka-kryo-serialization-typed* 2.1.0
+- Remove the direct dependency *akka-kryo-serialization*
 - Update *sbt-wartremover* to 2.4.13
 - Update *sbt-scoverage* to 1.8.2
+
 #### Use Akka Typed instead of Akka Classic
 - Use *akka-actor-typed* instead of *akka-actor*
 - Use *akka-cluster-typed* instead of *akka-cluster*

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -89,7 +89,7 @@ object Dependencies {
   }
 
   object Kryo {
-    val kryo = "io.altoo" %% "akka-kryo-serialization" % Versions.kryo
+    val kryo = "io.altoo" %% "akka-kryo-serialization-typed" % Versions.kryo
   }
 
   object H2 {

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
     val slick                    = "3.3.2"
     val expecty                  = "0.14.1"
     val janino                   = "3.0.16"
-    val kryo                     = "1.1.5"
+    val kryo                     = "2.1.0"
     val h2                       = "1.4.200"
     val mariadbConnectorJ        = "2.6.2"
     val sprayJson                = "1.3.5"


### PR DESCRIPTION
Closes #17 

次の2つの変更を行います。
### `akka-kryo-serialization` 1.1.0 => 2.1.0 に更新します

マイグレーションガイドを見ると、データがある場合には移行作業が必要なことがわかります。
lerna.g8 はテンプレートであるため、マイグレーションガイドに記載のある移行作業は必要ありません。
[akka-kryo-serialization/migration-guide.md at v2.1.0 · altoo-ag/akka-kryo-serialization](https://github.com/altoo-ag/akka-kryo-serialization/blob/v2.1.0/migration-guide.md#akka-kryo-serialization---migration-guide)

`akka-kryo-serialization` が依存している Akka は 2.6.12 であるため、問題なく機能すると思われます。
> https://github.com/altoo-ag/akka-kryo-serialization/blob/v2.1.0/build.sbt#L12
> `val defaultAkkaVersion = "2.6.12"`

Akka のバージョンも引き続き 2.6.12 であることが確認できます。
```
$ sbt dependencyList | grep akka | sort | uniq
[info] com.lerna-stack:akka-entity-replication_2.13:1.0.0+157-482a23b1-SNAPSHOT
[info] com.lerna-stack:lerna-util-akka_2.13:2.0.0-80f86b49-SNAPSHOT
[info] com.lightbend.akka:akka-stream-alpakka-cassandra_2.13:2.0.1
[info] com.typesafe.akka:akka-actor_2.13:2.6.12
[info] com.typesafe.akka:akka-actor-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-sharding_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-sharding-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-tools_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-coordination_2.13:2.6.12
[info] com.typesafe.akka:akka-distributed-data_2.13:2.6.12
[info] com.typesafe.akka:akka-http_2.13:10.2.4
[info] com.typesafe.akka:akka-http-core_2.13:10.2.4
[info] com.typesafe.akka:akka-http-spray-json_2.13:10.2.4
[info] com.typesafe.akka:akka-parsing_2.13:10.2.4
[info] com.typesafe.akka:akka-persistence_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence-cassandra_2.13:1.0.1
[info] com.typesafe.akka:akka-persistence-query_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-pki_2.13:2.6.12
[info] com.typesafe.akka:akka-protobuf-v3_2.13:2.6.12
[info] com.typesafe.akka:akka-remote_2.13:2.6.12
[info] com.typesafe.akka:akka-slf4j_2.13:2.6.12
[info] com.typesafe.akka:akka-stream_2.13:2.6.12
[info] com.typesafe.akka:akka-stream-typed_2.13:2.6.12
[info] io.altoo:akka-kryo-serialization_2.13:2.1.0
[info] io.altoo:akka-kryo-serialization-typed_2.13:2.1.0
```

### `akka-kryo-serialization-typed` を使用します
akka-kryo-serialization-typed は 2.1.0+ から使用できます。
`akka.actor.typed.ActorRef` などのシリアライザが提供されています。

次のテストコードから使用方法を確認できます。
> https://github.com/altoo-ag/akka-kryo-serialization/blob/v2.1.0/akka-kryo-serialization-typed/src/test/scala/io/altoo/akka/serialization/kryo/typed/serializer/TypedActorRefSerializerTest.scala#L13-L23