### PR TITLE
Scala 2.13.6 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 #### Dependency updates
-- Update *Scala* to 2.13.4
+- Update *Scala* to 2.13.6
 - Add *akka-entity-replication* 1.0.0+157-482a23b1-SNAPSHOT
 - Update *lerna-app-library* to 2.0.0-80f86b49-SNAPSHOT
 - Update *scalatest* to 3.1.4

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / name := "myapp"
 ThisBuild / description := "description"
 ThisBuild / version := "1.0.0"
 ThisBuild / organization := "organization"
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.6"
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation",
   "-feature",


### PR DESCRIPTION
Closes #15 

Scala 2.13.4 から Scala 2.13.6 に更新します。

## リリースノート
リリースノートは次のリンクから確認できます。
- [Release Scala 2.13.5 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.5)
- [Release Scala 2.13.6 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.6)

## 動作確認
README に記載の次の内容を動作確認しました。

* HTTP API が動作していること
  ```
  curl --silent --noproxy "*" http://127.0.0.1:9001/index
  curl --silent --noproxy "*" http://127.0.0.1:9002/version
  curl --silent --noproxy "*" http://127.0.0.1:9002/commit-hash
  curl --silent --noproxy "*" http://127.0.0.2:9001/index
  curl --silent --noproxy "*" http://127.0.0.2:9002/version
  curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
  ```
* テストカバレッジを取得できること
`sbt take-test-coverage`
* Slick コード生成が動作すること
`sbt slick-codegen/run`
* RPM パッケージをビルドできること  
`docker-compose run --rm sbt-rpmbuild clean rpm:packageBin`
このコマンドは `sbt new file://lerna.g8 --name=lerna-example` してできたプロジェクトを、
git にチェックインした後に実行する必要があります。