### PR TITLE
Slick 3.3.3 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update *akka-http* to 10.2.4
 - Add *akka-kryo-serialization-typed* 2.1.0
 - Remove the direct dependency *akka-kryo-serialization*
+- Update *slick* to 3.3.3
 - Update *sbt-wartremover* to 2.4.13
 - Update *sbt-scoverage* to 1.8.2
 

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val scalaTest                = "3.1.4"
     val airframe                 = "20.9.0"
     val logback                  = "1.2.3"
-    val slick                    = "3.3.2"
+    val slick                    = "3.3.3"
     val expecty                  = "0.14.1"
     val janino                   = "3.0.16"
     val kryo                     = "2.1.0"


### PR DESCRIPTION
Closes #26 

## リリースノート
[Release Slick 3.3.3 release · slick/slick](https://github.com/slick/slick/releases/tag/v3.3.3)

## 動作確認
`sbt slick-codegen/run` が動作することを確認しました。