### PR TITLE
akka-projection 1.1.0 を追加する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update *akka-http* to 10.2.4
 - Add *akka-kryo-serialization-typed* 2.1.0
 - Remove the direct dependency *akka-kryo-serialization*
+- Add *akka-projection-eventsourced* 1.1.0
+- Add *akka-projection-slick* 1.1.0
 - Update *slick* to 3.3.3
 - Update *sbt-wartremover* to 2.4.13
 - Update *sbt-scoverage* to 1.8.2

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -131,6 +131,8 @@ lazy val `application` = (project in file("app/application"))
       Akka.clusterTools,
       Akka.persistenceQuery,
       AkkaPersistenceCassandra.akkaPersistenceCassandra,
+      AkkaProjection.eventsourced,
+      AkkaProjection.slick,
       Kryo.kryo,
       SprayJson.sprayJson,
       Akka.actorTestKit       % Test,

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"
+    val akkaProjection           = "1.1.0"
     val scalaTest                = "3.1.4"
     val airframe                 = "20.9.0"
     val logback                  = "1.2.3"
@@ -56,6 +57,11 @@ object Dependencies {
   object AkkaPersistenceCassandra {
     val akkaPersistenceCassandra =
       "com.typesafe.akka" %% "akka-persistence-cassandra" % Versions.akkaPersistenceCassandra
+  }
+
+  object AkkaProjection {
+    val eventsourced = "com.lightbend.akka" %% "akka-projection-eventsourced" % Versions.akkaProjection
+    val slick        = "com.lightbend.akka" %% "akka-projection-slick"        % Versions.akkaProjection
   }
 
   object ScalaTest {


### PR DESCRIPTION
Closes #23 

Akka Projection を使用することを推奨しているため、
次の2つを依存ライブラリに追加します。
- akka-projection-eventsourced 1.1.0
- akka-projection-slick 1.1.0

## 使用できる Akka Projection のバージョン
Akka 2.6.12 と組み合わせられる必要があります。
Akka Projection 最新版 1.2.0+ は Akka 2.6.14+ を要求するため、使用することはできません。
https://doc.akka.io/docs/akka-projection/1.2.0/overview.html#akka-version
Akka Projection 1.1.0 は Akka 2.6.10+ を要求するため、使用することができます。
https://doc.akka.io/docs/akka-projection/1.1.0/overview.html#akka-version

## Akka Projection を追加するプロジェクト
https://github.com/lerna-stack/lerna-sample-payment-app/blob/v1.1.0/build.sbt#L177-L212
を参考に、`application` プロジェクトに akka-projection-eventsourced, akka-projection-slick を追加しました。

## Dependencies

次の項目を確認しました。
- Akka Projection 1.1.0 が使用されていること
- Akka 2.6.12 が使用されていること

```
$ sbt application/dependencyList | grep akka
[info] com.lerna-stack:akka-entity-replication_2.13:1.0.0+157-482a23b1-SNAPSHOT
[info] com.lerna-stack:lerna-util-akka_2.13:2.0.0-80f86b49-SNAPSHOT
[info] com.lightbend.akka:akka-projection-core_2.13:1.1.0
[info] com.lightbend.akka:akka-projection-eventsourced_2.13:1.1.0
[info] com.lightbend.akka:akka-projection-jdbc_2.13:1.1.0
[info] com.lightbend.akka:akka-projection-slick_2.13:1.1.0
[info] com.lightbend.akka:akka-stream-alpakka-cassandra_2.13:2.0.1
[info] com.typesafe.akka:akka-actor-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-actor_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-sharding-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-sharding_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-tools_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-cluster_2.13:2.6.12
[info] com.typesafe.akka:akka-coordination_2.13:2.6.12
[info] com.typesafe.akka:akka-distributed-data_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence-cassandra_2.13:1.0.1
[info] com.typesafe.akka:akka-persistence-query_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-persistence_2.13:2.6.12
[info] com.typesafe.akka:akka-pki_2.13:2.6.12
[info] com.typesafe.akka:akka-protobuf-v3_2.13:2.6.12
[info] com.typesafe.akka:akka-remote_2.13:2.6.12
[info] com.typesafe.akka:akka-slf4j_2.13:2.6.12
[info] com.typesafe.akka:akka-stream-typed_2.13:2.6.12
[info] com.typesafe.akka:akka-stream_2.13:2.6.12
[info] io.altoo:akka-kryo-serialization-typed_2.13:2.1.0
[info] io.altoo:akka-kryo-serialization_2.13:2.1.0
```