### PR TITLE
StandardSpec で should.matchers を使用する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- `StandardSpec` uses *should.matchers* instead of *must.matchers*  
+  Since the `ScalaTestWithActorTestKit` uses *should.matchers*,
+  the change makes us easy to use both `StandardSpec` and`ScalaTestWithActorTestKit` at the same time.
 
 #### Dependency updates
 - Update *Scala* to 2.13.6

--- a/src/main/g8/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
+++ b/src/main/g8/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
@@ -1,7 +1,7 @@
 package myapp.utility.scalatest
 
 import lerna.util.lang.Equals
-import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 trait StandardSpec extends AnyWordSpecLike with SpecAssertions with Equals with Matchers


### PR DESCRIPTION
Closes #30 

ScalaTestWithActorTestKit で should.matchers が使用されているため、
この変更によって、 StandardSpec と ScalaTestWithActorTestKit を同時に使用することが容易になります。