### PR TITLE
typed.ActorSystem を使用する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     We don't need to specify the dependency since we use *akka-actor-typed* instead.
 - Add *akka-persistence-testkit*  
     It would be great to test `EventSourcedBehavior`s
+- Use `typed.ActorSystem[T]` instead of classic `ActorSystem`  
+    It is recommended to use `typed.ActorSystem` rather than classic `ActorSystem` for new projects.
 
 ## 1.x
 - Initial release

--- a/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/DIDesign.scala
+++ b/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/DIDesign.scala
@@ -1,6 +1,6 @@
 package myapp.entrypoint
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import com.typesafe.config.Config
 import myapp.presentation.PresentationDIDesign
 import wvlet.airframe._
@@ -8,10 +8,10 @@ import wvlet.airframe._
 @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
 object DIDesign {
   @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity"))
-  def design(system: ActorSystem): Design =
+  def design(system: ActorSystem[Nothing]): Design =
     newDesign
-      .bind[ActorSystem].toInstance(system)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[MyApp].toSingleton
-      .bind[Config].toSingletonProvider[ActorSystem] { system => system.settings.config }
+      .bind[Config].toSingletonProvider[ActorSystem[Nothing]] { system => system.settings.config }
       .add(PresentationDIDesign.presentationDesign)
 }

--- a/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/Main.scala
+++ b/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/Main.scala
@@ -1,6 +1,8 @@
 package myapp.entrypoint
 
-import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.actor.CoordinatedShutdown
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.cluster.Cluster
 import com.typesafe.config.ConfigFactory
 import lerna.log.AppLogging
@@ -34,7 +36,8 @@ object Main extends App with AppLogging {
     System.exit(1)
   }
 
-  private val system: ActorSystem = ActorSystem("MyAppSystem", config)
+  private val system: ActorSystem[Nothing] =
+    ActorSystem[Nothing](Behaviors.empty, "MyAppSystem", config)
   logger.info("ActorSystem({})起動完了", system)
 
   val cluster = Cluster(system)

--- a/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
+++ b/src/main/g8/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
@@ -1,7 +1,8 @@
 package myapp.entrypoint
 
 import akka.Done
-import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.actor.CoordinatedShutdown
+import akka.actor.typed.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.server.Route
@@ -12,11 +13,11 @@ import myapp.presentation.RootRoute
 
 @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
 class MyApp(implicit
-    val actorSystem: ActorSystem,
+    val actorSystem: ActorSystem[Nothing],
     rootRoute: RootRoute,
     config: Config,
 ) extends AppLogging {
-  import actorSystem.dispatcher
+  import actorSystem.executionContext
 
   def start(): Unit = {
     val privateInternetInterface = config.getString("myapp.private-internet.http.interface")

--- a/src/main/g8/app/entrypoint/src/test/scala/myapp/entrypoint/DIDesignSpec.scala
+++ b/src/main/g8/app/entrypoint/src/test/scala/myapp/entrypoint/DIDesignSpec.scala
@@ -1,6 +1,7 @@
 package myapp.entrypoint
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import com.typesafe.config.Config
 import lerna.testkit.airframe.DISessionSupport
 import myapp.utility.scalatest.StandardSpec
@@ -9,7 +10,7 @@ import wvlet.airframe.Design
 @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
 class DIDesignSpec extends StandardSpec with DISessionSupport {
 
-  private val system: ActorSystem = ActorSystem()
+  private val system = ActorSystem(Behaviors.empty, "MyAppSystem")
 
   override protected val diDesign: Design = DIDesign.design(system).withProductionMode
 


### PR DESCRIPTION
Closes #29 

新規プロジェクトでは classic ActorSystem の代わりに typed.ActorSystem を使用することを推奨しています。

## 動作確認
起動部分を変更したため、 HTTP API が動作していることを念のため確認しました。

```
curl --silent --noproxy "*" http://127.0.0.1:9001/index
curl --silent --noproxy "*" http://127.0.0.1:9002/version
curl --silent --noproxy "*" http://127.0.0.1:9002/commit-hash
curl --silent --noproxy "*" http://127.0.0.2:9001/index
curl --silent --noproxy "*" http://127.0.0.2:9002/version
curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
```