### PR TITLE
lerna-app-library-2.0.0-ab5c7912-SNAPSHOT に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Dependency updates
 - Update *Scala* to 2.13.6
 - Add *akka-entity-replication* 1.0.0+157-482a23b1-SNAPSHOT
-- Update *lerna-app-library* to 2.0.0-80f86b49-SNAPSHOT
+- Update *lerna-app-library* to 2.0.0-ab5c7912-SNAPSHOT
 - Update *scalatest* to 3.1.4
 - Update *akka* to 2.6.12
 - Update *akka-http* to 10.2.4

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val akkaEntityReplication    = "1.0.0+157-482a23b1-SNAPSHOT"
-    val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
+    val lerna                    = "2.0.0-ab5c7912-SNAPSHOT"
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"


### PR DESCRIPTION
https://github.com/lerna-stack/lerna.g8/issues/1 の取り組みとして、
lerna-app-library を 最新版SNAPSHOT に更新します。

この更新には、次の変更が含まれています。
```
$ git rev-list --oneline --merges 80f86b49...ab5c7912
ab5c7912d Merge pull request #41 from lerna-stack/lerna-management/remove-unnecessary-dependencies
e1263585d Merge pull request #40 from lerna-stack/lerna-management/remove-environment-dependent-tests
6ee167b8c Merge pull request #38 from lerna-stack/test-agaist-java8-and-java11
28df6ff91 Merge pull request #39 from lerna-stack/update-sbt-auto-api-mappings-to-3.0.0
5d47d25eb Merge pull request #5 from lerna-stack/fix/lerna-log/mdc
42df00e53 Merge pull request #36 from lerna-stack/fix/lerna-http/log
```

「追記」
publish 済みの SNAPSHOT は次のリンクから確認できます。
https://oss.sonatype.org/content/repositories/snapshots/com/lerna-stack/