### PR TITLE
akka-entity-replication-1.0.0+183-38b36c52-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Dependency updates
 - Update *Scala* to 2.13.6
-- Add *akka-entity-replication* 1.0.0+157-482a23b1-SNAPSHOT
+- Add *akka-entity-replication* 1.0.0+183-38b36c52-SNAPSHOT
 - Update *lerna-app-library* to 2.0.0-ab5c7912-SNAPSHOT
 - Update *scalatest* to 3.1.4
 - Update *akka* to 2.6.12

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "1.0.0+157-482a23b1-SNAPSHOT"
+    val akkaEntityReplication    = "1.0.0+183-38b36c52-SNAPSHOT"
     val lerna                    = "2.0.0-ab5c7912-SNAPSHOT"
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"


### PR DESCRIPTION
#3  の取り組みとして、
akka-entity-replication を 最新版SNAPSHOT に更新します。

この更新には、akka-entity-replication の次の変更が含まれています。

```
$ git rev-list --oneline --merges 482a23b1...38b36c52
38b36c52 Merge pull request #92 from lerna-stack/chore/version-up/scala-pb
cd6339e7 Merge pull request #88 from lerna-stack/programmatic-persistence-plugin-id
5004f441 Merge pull request #91 from lerna-stack/hide-internal-typed-api
58abd134 Merge pull request #90 from lerna-stack/test-against-java8-and-java11
```

publish 済みの SNAPSHOT は次のリンクから確認できます。
https://oss.sonatype.org/content/repositories/snapshots/com/lerna-stack/akka-entity-replication_2.13/