### PR TITLE
README の scoverage report に関する記述を改善

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -85,7 +85,7 @@ curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
 sbt take-test-coverage
 ```
 
-テストカバレッジは、`./target\scala-2.12\scoverage-report`に出力されます。
+テストカバレッジは、`./target\scala-2.13\scoverage-report`に出力されます。
 
 ## データベースのスキーマを更新する
 

--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -85,7 +85,7 @@ curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
 sbt take-test-coverage
 ```
 
-テストカバレッジは、`./target\scala-2.13\scoverage-report`に出力されます。
+テストカバレッジは、`./target/scala-2.13/scoverage-report`に出力されます。
 
 ## データベースのスキーマを更新する
 


### PR DESCRIPTION
- ディレクトリ間違い修正 (Scala 2.12 -> 2.13)
- ディレクトリ区切り文字を統一 ( `/`, `\` )