### PR TITLE
バージョン戦略を改訂する

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ use the following commands according to the purpose.
 # Create a new project from the `develop` branch (unstable).
 sbt new lerna-stack/lerna.g8 --branch develop
 
-# Create a new project from the `v2020.12.0` tag (stable, but not the latest).
+# Create a new project from the `v2020.12.0` tag (stable, may not be the latest).
 sbt new lerna-stack/lerna.g8 --tag v2020.12.0
 ```
 
@@ -44,7 +44,7 @@ we use [Calendar Versioning](https://calver.org/) rather than [Semantic Versioni
 - `develop` (unstable)
 
 ### Tags
-Tag is useful to use a stable version but not the latest.  
+Tag is useful to use a specific stable version.  
 You can check all releases on [Releases · lerna-stack/lerna.g8](https://github.com/lerna-stack/lerna.g8/tags).
 
 ## Template license

--- a/README.md
+++ b/README.md
@@ -5,8 +5,20 @@ A [Giter8][g8] template for a project to be adopting [Lerna Project](https://git
 This project provides a *g8* template for a project to be adopting *Lerna*.
 To create a new project using this template, Use `sbt new` like below.
 
-```shell script
+```shell
+# Create a new project from the `main` branch (stable, the latest).
 sbt new lerna-stack/lerna.g8
+```
+
+If you want to use another version,
+use the following commands according to the purpose.
+
+```shell
+# Create a new project from the `develop` branch (unstable).
+sbt new lerna-stack/lerna.g8 --branch develop
+
+# Create a new project from the `v2020.12.0` tag (stable, but not the latest).
+sbt new lerna-stack/lerna.g8 --tag v2020.12.0
 ```
 
 ## Parameters
@@ -22,6 +34,18 @@ You can change the below properties to fit your purpose.
 We want to maintain the containing template project as compilable.
 Gitter8's template string processing is powerful,
 but it will be hard to maintain the template project as compilable.
+
+## Versioning Strategy
+Since lerna.g8 provides a combination of third partie's libraries (like a BOM),
+we use [Calendar Versioning](https://calver.org/) rather than [Semantic Versioning](https://semver.org/).
+
+### Branches
+- `main` (default, stable, the latest)
+- `develop` (unstable)
+
+### Tags
+Tag is useful to use a stable version but not the latest.  
+You can check all releases on [Releases · lerna-stack/lerna.g8](https://github.com/lerna-stack/lerna.g8/tags).
 
 ## Template license
 Written in 2020 by TIS Inc.


### PR DESCRIPTION
lerna.g8 は サードパーティーのライブラリの組み合わせを提供する (BOM のような)ものであるため、[Semantic Versioning 2.0.0 | Semantic Versioning](https://semver.org/) ではなく [Calendar Versioning — CalVer](https://calver.org/) を使用するほうが理に適っているように思えます。

この PR では バージョン戦略について README に記載します。
また、`sbt new` で branch や tag を指定する方法も記載しました。

`sbt new` の使い方は次のページで確認できます。
- [sbt Reference Manual — sbt new and Templates](https://www.scala-sbt.org/1.x/docs/sbt-new-and-Templates.html#Giter8+parameters)
- [Giter8 — Usage](http://www.foundweekends.org/giter8/usage.html#Usage)

## レビュー中&マージ前に実施すること
- [x] cc602f927e5dd89c08d63b096d8ce0ab51f04a91 から `v2020.12.0` タグ を作成します
- [x] `1.x` ブランチ から `main` ブランチを作成します
- [x] `main` ブランチをデフォルトに変更します
- [x] この PR のターゲットを `main` ブランチに変更します
- [x] `1.x` ブランチを削除します
- [ ] この PR をマージします

## マージ後に実施すること
- [ ] `main` ブランチを `develop` ブランチにマージします