### PR TITLE
Jackson を Kryo の代わりに使用する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove *akka-kryo-serialization*  
   Use *akka-serialization-jackson* instead.  
   We'd like to use JSON as a serialization format for persistence.
+- Add *akka-serialization-jackson* 2.6.12  
+  The version is the same as other Akka modules.
+- Add *jackson* modules (the version is 2.12.3) as direct dependencies  
+  It would be great that all *jackson* modules should be the same version.
 - Add *akka-projection-eventsourced* 1.1.0
 - Add *akka-projection-slick* 1.1.0
 - Update *slick* to 3.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update *scalatest* to 3.1.4
 - Update *akka* to 2.6.12
 - Update *akka-http* to 10.2.4
-- Add *akka-kryo-serialization-typed* 2.1.0
-- Remove the direct dependency *akka-kryo-serialization*
+- Remove *akka-kryo-serialization*  
+  Use *akka-serialization-jackson* instead.  
+  We'd like to use JSON as a serialization format for persistence.
 - Add *akka-projection-eventsourced* 1.1.0
 - Add *akka-projection-slick* 1.1.0
 - Update *slick* to 3.3.3

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -130,6 +130,7 @@ lazy val `application` = (project in file("app/application"))
       Akka.clusterSharding,
       Akka.clusterTools,
       Akka.persistenceQuery,
+      Akka.serializationJackson,
       AkkaPersistenceCassandra.akkaPersistenceCassandra,
       AkkaProjection.eventsourced,
       AkkaProjection.slick,
@@ -138,7 +139,7 @@ lazy val `application` = (project in file("app/application"))
       Akka.multiNodeTestKit   % Test,
       Akka.streamTestKit      % Test,
       Akka.persistenceTestKit % Test,
-    ),
+    ) ++ Jackson.all,
   )
 
 lazy val `read-model` = (project in file("app/read-model"))
@@ -204,6 +205,10 @@ lazy val `testkit` = (project in file("app/testkit"))
       ScalaTest.scalaTest,
       Airframe.airframe,
       WireMock.wireMock,
+      // WireMock が依存する Jackson のバージョンを固定する
+      Jackson.core,
+      Jackson.annotations,
+      Jackson.databind,
     ),
   )
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -133,7 +133,6 @@ lazy val `application` = (project in file("app/application"))
       AkkaPersistenceCassandra.akkaPersistenceCassandra,
       AkkaProjection.eventsourced,
       AkkaProjection.slick,
-      Kryo.kryo,
       SprayJson.sprayJson,
       Akka.actorTestKit       % Test,
       Akka.multiNodeTestKit   % Test,

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
     val h2                       = "1.4.200"
     val mariadbConnectorJ        = "2.6.2"
     val sprayJson                = "1.3.5"
+    val jackson                  = "2.12.3"
   }
 
   object Lerna {
@@ -34,17 +35,18 @@ object Dependencies {
   }
 
   object Akka {
-    val actor              = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
-    val stream             = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
-    val cluster            = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
-    val clusterSharding    = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
-    val clusterTools       = "com.typesafe.akka" %% "akka-cluster-tools"          % Versions.akka
-    val persistence        = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
-    val persistenceQuery   = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
-    val actorTestKit       = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
-    val streamTestKit      = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
-    val multiNodeTestKit   = "com.typesafe.akka" %% "akka-multi-node-testkit"     % Versions.akka
-    val persistenceTestKit = "com.typesafe.akka" %% "akka-persistence-testkit"    % Versions.akka
+    val actor                = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
+    val stream               = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
+    val cluster              = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
+    val clusterSharding      = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
+    val clusterTools         = "com.typesafe.akka" %% "akka-cluster-tools"          % Versions.akka
+    val persistence          = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
+    val persistenceQuery     = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
+    val actorTestKit         = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
+    val serializationJackson = "com.typesafe.akka" %% "akka-serialization-jackson"  % Versions.akka
+    val streamTestKit        = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
+    val multiNodeTestKit     = "com.typesafe.akka" %% "akka-multi-node-testkit"     % Versions.akka
+    val persistenceTestKit   = "com.typesafe.akka" %% "akka-persistence-testkit"    % Versions.akka
   }
 
   object AkkaHttp {
@@ -103,6 +105,26 @@ object Dependencies {
 
   object WireMock {
     val wireMock = "com.github.tomakehurst" % "wiremock-jre8" % "2.27.2"
+  }
+
+  // NOTE
+  // 依存ライブラリによって、要求する Jackson のバージョンが異なる(例えば `2.11.0` と `2.10.5`)。
+  // 使用しているマイナーバージョンが異なるとランタイムエラーが発生することがあるため、
+  // プロジェクト全体で Jackson のバージョンを固定するほうが良い。
+  // Jackson の マイナーバージョン は後方互換性を維持するように努められているため、
+  // メジャーバージョンが同一である、最新のマイナーバージョンを指定すればよい。
+  // https://github.com/FasterXML/jackson-docs#on-jackson-versioning
+  object Jackson {
+    lazy val all =
+      Seq(core, annotations, databind, dataFormatCbor, datatypeJDK8, datatypeJSR310, moduleScala, moduleParameterNames)
+    val core                 = "com.fasterxml.jackson.core"       % "jackson-core"                   % Versions.jackson
+    val annotations          = "com.fasterxml.jackson.core"       % "jackson-annotations"            % Versions.jackson
+    val databind             = "com.fasterxml.jackson.core"       % "jackson-databind"               % Versions.jackson
+    val dataFormatCbor       = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor"        % Versions.jackson
+    val datatypeJDK8         = "com.fasterxml.jackson.datatype"   % "jackson-datatype-jdk8"          % Versions.jackson
+    val datatypeJSR310       = "com.fasterxml.jackson.datatype"   % "jackson-datatype-jsr310"        % Versions.jackson
+    val moduleScala          = "com.fasterxml.jackson.module"    %% "jackson-module-scala"           % Versions.jackson
+    val moduleParameterNames = "com.fasterxml.jackson.module"     % "jackson-module-parameter-names" % Versions.jackson
   }
 
 }

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -15,7 +15,6 @@ object Dependencies {
     val slick                    = "3.3.3"
     val expecty                  = "0.14.1"
     val janino                   = "3.0.16"
-    val kryo                     = "2.1.0"
     val h2                       = "1.4.200"
     val mariadbConnectorJ        = "2.6.2"
     val sprayJson                = "1.3.5"
@@ -92,10 +91,6 @@ object Dependencies {
 
   object Janino {
     val janino = "org.codehaus.janino" % "janino" % Versions.janino
-  }
-
-  object Kryo {
-    val kryo = "io.altoo" %% "akka-kryo-serialization-typed" % Versions.kryo
   }
 
   object H2 {


### PR DESCRIPTION
JSON を永続化フォーマットとして使用する方針となりました。
この PR では akka-kryo-serialization を依存から削除し、 代わりに akka-serialization-jackson を追加します。

akka-serialization-jackson の公式ドキュメントは次のリンクから確認できます。
[Serialization with Jackson • Akka Documentation](https://doc.akka.io/docs/akka/current/serialization-jackson.html#serialization-with-jackson)

## Jackson の依存関係について

Jackson の依存関係には注意が必要です。
次のようなエラーが出たため、Jackson のバージョンをプロジェクト全体で統一するほうがよさそうです。
すべてを統一する必要はないかもしれませんが、統一しておくほうがよさそうに思っています。
```
info] myapp.entrypoint.DIDesignSpec *** ABORTED ***
[info]   com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.5 requires Jackson Databind version >= 2.10.0 and < 2.11.0
[info]   at com.fasterxml.jackson.module.scala.JacksonModule.setupModule(JacksonModule.scala:61)
[info]   at com.fasterxml.jackson.module.scala.JacksonModule.setupModule$(JacksonModule.scala:46)
[info]   at com.fasterxml.jackson.module.scala.DefaultScalaModule.setupModule(DefaultScalaModule.scala:17)
[info]   at com.fasterxml.jackson.databind.ObjectMapper.registerModule(ObjectMapper.java:818)
[info]   at akka.serialization.jackson.JacksonObjectMapperProvider$.$anonfun$configureObjectMapperModules$4(JacksonObjectMapperProvider.scala:242)
[info]   at akka.serialization.jackson.JacksonObjectMapperProvider$.$anonfun$configureObjectMapperModules$4$adapted(JacksonObjectMapperProvider.scala:241)
[info]   at scala.collection.immutable.List.foreach(List.scala:333)
[info]   at akka.serialization.jackson.JacksonObjectMapperProvider$.configureObjectMapperModules(JacksonObjectMapperProvider.scala:241)
[info]   at akka.serialization.jackson.JacksonObjectMapperProvider$.createObjectMapper(JacksonObjectMapperProvider.scala:265)
[info]   at akka.serialization.jackson.JacksonObjectMapperProvider.create(JacksonObjectMapperProvider.scala:359)
```

### Jackson のバージョニングについて
[On Jackson versioning | FasterXML/jackson-docs: Documentation for the Jackson JSON processor.](https://github.com/FasterXML/jackson-docs#on-jackson-versioning)
からわかるように、マイナーバージョン間には後方互換性があるように努められています。

メジャーバージョンが変わらない、最新バージョン `2.12.3` を使用します。
`jackson` のリリースされているバージョンは次の URL から確認できます。
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core

### バージョン固定前
```
$ sbt "dependencyList" | sort | uniq | grep jackson
[info] com.fasterxml.jackson.core:jackson-annotations:2.10.5
[info] com.fasterxml.jackson.core:jackson-annotations:2.11.0
[info] com.fasterxml.jackson.core:jackson-core:2.10.5
[info] com.fasterxml.jackson.core:jackson-core:2.11.0
[info] com.fasterxml.jackson.core:jackson-databind:2.10.5.1
[info] com.fasterxml.jackson.core:jackson-databind:2.11.0
[info] com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5
[info] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.5
[info] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.5
[info] com.fasterxml.jackson.module:jackson-module-parameter-names:2.10.5
[info] com.fasterxml.jackson.module:jackson-module-paranamer:2.10.5
[info] com.fasterxml.jackson.module:jackson-module-scala_2.13:2.10.5
[info] com.typesafe.akka:akka-serialization-jackson_2.13:2.6.12
```

### バージョン固定後
```
$ sbt "dependencyList" | sort | uniq | grep jackson
[info] com.fasterxml.jackson.core:jackson-annotations:2.12.3
[info] com.fasterxml.jackson.core:jackson-core:2.12.3
[info] com.fasterxml.jackson.core:jackson-databind:2.12.3
[info] com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.3
[info] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.3
[info] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3
[info] com.fasterxml.jackson.module:jackson-module-parameter-names:2.12.3
[info] com.fasterxml.jackson.module:jackson-module-scala_2.13:2.12.3
[info] com.typesafe.akka:akka-serialization-jackson_2.13:2.6.12
```