### PR TITLE
chore: docker-compose up 時にデフォルトで sbt-rpmbuild を作成しないように変更

### DIFF
--- a/src/main/g8/docker-compose.yml
+++ b/src/main/g8/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       retries: 60
 
   sbt-rpmbuild:
+    profiles:
+      - build
     build:
       context: docker/sbt-rpmbuild
       args:


### PR DESCRIPTION
通常使用しないものなのに、build/runされるのは面倒なため

docker-compose prifiles を使用

Using profiles with Compose | Docker Documentation
https://docs.docker.com/compose/profiles/

## 関連
- https://github.com/lerna-stack/lerna-sample-payment-app/pull/13
- https://github.com/lerna-stack/lerna-sample-account-app/pull/11