### PR TITLE
akka-entity-replication 2.0.0 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Dependency updates
 - Update *Scala* to 2.13.6
-- Add *akka-entity-replication* 1.0.0+183-38b36c52-SNAPSHOT
+- Add *akka-entity-replication* 2.0.0
 - Update *lerna-app-library* to 2.0.0-ab5c7912-SNAPSHOT
 - Update *scalatest* to 3.1.4
 - Update *akka* to 2.6.12

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "1.0.0+188-a673fe8d-SNAPSHOT"
+    val akkaEntityReplication    = "2.0.0"
     val lerna                    = "2.0.0-ab5c7912-SNAPSHOT"
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"


### PR DESCRIPTION
Closes #3 

akka-entity-replication 2.0.0 がリリースされました。2.0.0 に更新します。
https://github.com/lerna-stack/akka-entity-replication/releases/tag/v2.0.0