### PR TITLE
lerna-app-library 2.0.0 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Dependency updates
 - Update *Scala* to 2.13.6
 - Add *akka-entity-replication* 2.0.0
-- Update *lerna-app-library* to 2.0.0-ab5c7912-SNAPSHOT
+- Update *lerna-app-library* to 2.0.0
 - Update *scalatest* to 3.1.4
 - Update *akka* to 2.6.12
 - Update *akka-http* to 10.2.4

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val akkaEntityReplication    = "2.0.0"
-    val lerna                    = "2.0.0-ab5c7912-SNAPSHOT"
+    val lerna                    = "2.0.0"
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna.g8/issues/1

lerna-app-library 2.0.0 がリリースされました。2.0.0 に更新します。
https://github.com/lerna-stack/lerna-app-library/releases/tag/v2.0.0