### PR TITLE
Sonatype Snapshot Repository を Resolvers から削除する

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -36,9 +36,6 @@ ThisBuild / fork in Test := true
 // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき紛らわしいため
 ThisBuild / outputStrategy := Some(StdoutOutput)
 
-// TODO SNAPSHOT を使用しなくなったら SNAPSHOT用の resolver は削除すること
-ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
-
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, JavaServerAppPackaging, RpmPlugin, SystemdPlugin)
   .aggregate(


### PR DESCRIPTION
SNAPSHOT を使わないようになったため、不要になりました。