### PR TITLE
Prepare to release 2021.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+
+
+## 2021.7.0
 ### Changed
 - `StandardSpec` uses *should.matchers* instead of *must.matchers*  
   Since the `ScalaTestWithActorTestKit` uses *should.matchers*,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,5 +41,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use `typed.ActorSystem[T]` instead of classic `ActorSystem`  
     It is recommended to use `typed.ActorSystem` rather than classic `ActorSystem` for new projects.
 
-## 1.x
+## 2020.12.0
 - Initial release

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ but it will be hard to maintain the template project as compilable.
 
 ## Versioning Strategy
 Since lerna.g8 provides a combination of third partie's libraries (like a BOM),
-we use [Calendar Versioning](https://calver.org/) rather than [Semantic Versioning](https://semver.org/).
+we use [Calendar Versioning](https://calver.org/) `YYYY.MM.MICRO` rather than [Semantic Versioning](https://semver.org/).
 
 ### Branches
 - `main` (default, stable, the latest)


### PR DESCRIPTION
## NOTE
`lerna.g8` 自身のバージョンをコードなどで記載している箇所はありません。
バージョンは変更点や使用バージョンがわかりやすいように付与しています。

```
$ git grep -iF '1.0.0'
CHANGELOG.md:The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
src/main/g8/CHANGELOG.md:このファイルの書き方に関する推奨事項については、[Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) を確認してください。
src/main/g8/build.sbt:ThisBuild / version := "1.0.0"
```

## TODO (after merge)
- [ ] Merge `develop` into `main`
- [ ] Create Tag `2021.7.0` from `main`