### PR TITLE
PowerAssertionsSupport.expect は1つの assertion のみを処理する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- SpecAssertions.expect handles only single assertion.
+  The multiple assertions will not be supported.
 
 
 ## [v2021.7.0] - 2021-7-16

--- a/src/main/g8/app/presentation/src/test/scala/myapp/presentation/application/ApplicationRouteSpec.scala
+++ b/src/main/g8/app/presentation/src/test/scala/myapp/presentation/application/ApplicationRouteSpec.scala
@@ -17,10 +17,8 @@ class ApplicationRouteSpec extends StandardSpec with ScalatestRouteTest with DIS
 
     "reply OK" in {
       Get("/index") ~> route.route ~> check {
-        expect {
-          status === StatusCodes.OK
-          responseAs[String] === "OK"
-        }
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "OK")
       }
     }
 

--- a/src/main/g8/app/presentation/src/test/scala/myapp/presentation/management/VersionRouteSpec.scala
+++ b/src/main/g8/app/presentation/src/test/scala/myapp/presentation/management/VersionRouteSpec.scala
@@ -24,19 +24,15 @@ class VersionRouteSpec extends StandardSpec with ScalatestRouteTest with DISessi
 
     "設定されたバージョン番号を返す" in {
       Get("/version") ~> route.route ~> check {
-        expect {
-          status === StatusCodes.OK
-          responseAs[String] === "0.1.0"
-        }
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "0.1.0")
       }
     }
 
     "設定されたコミットハッシュを返す" in {
       Get("/commit-hash") ~> route.route ~> check {
-        expect {
-          status === StatusCodes.OK
-          responseAs[String] === "8653fe0c05bc1a88e2e5bc96892373e365ffc898"
-        }
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "8653fe0c05bc1a88e2e5bc96892373e365ffc898")
       }
     }
   }

--- a/src/main/g8/app/testkit/src/test/scala/myapp/utility/scalatest/StandardSpecExample.scala
+++ b/src/main/g8/app/testkit/src/test/scala/myapp/utility/scalatest/StandardSpecExample.scala
@@ -16,25 +16,6 @@ class StandardSpecExample extends StandardSpec {
         */
     }
 
-    "複数項目チェックする場合" in {
-      expect {
-        "1" === "1"
-        "2" === "2"
-      }
-
-      /** エラー出力の例：
-        * java.lang.AssertionError:
-        *
-        * "2" === "1"
-        * |   |
-        * 2   false
-        *
-        * "3" === "2"
-        * |   |
-        * 3   false
-        */
-    }
-
     "条件を満たさない場合はAssertionErrorになる" in {
       assertThrows[AssertionError] {
         expect("1" === "2")


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna.g8/issues/49

複数の assertion を処理することを非サポートにします。
PowerAssertionsSupport.expect の使用箇所を調べて、複数の expect になるように書き換えました。