### PR TITLE
Update Lerna modules to latest snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Dependency Updates
+- Update *lerna-app-library* to 3.0.0-6-ca3f2b2b-SNAPSHOT from 3.0.0
+- Update *akka-entity-replication* to 2.0.0+111-c87ff6bc-SNAPSHOT from 2.0.0
+- Update *akka* to 2.6.17 from 2.6.12  
+  *akka-entity-replication* recommends we use the same version of Akka.
+
 
 ## [v2021.10.0] - 2021-10-22
 [v2021.10.0]: https://github.com/lerna-stack/lerna.g8/compare/v2021.7.0...v2021.10.0

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -36,6 +36,9 @@ ThisBuild / fork in Test := true
 // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき紛らわしいため
 ThisBuild / outputStrategy := Some(StdoutOutput)
 
+// TODO Remove this snapshot repo after stable version release
+ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
+
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, JavaServerAppPackaging, RpmPlugin, SystemdPlugin)
   .aggregate(

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "2.0.0"
+    val akkaEntityReplication    = "2.0.0+111-c87ff6bc-SNAPSHOT"
     val lerna                    = "3.0.0"
-    val akka                     = "2.6.12"
+    val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"
     val akkaProjection           = "1.1.0"

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val akkaEntityReplication    = "2.0.0+111-c87ff6bc-SNAPSHOT"
-    val lerna                    = "3.0.0"
+    val lerna                    = "3.0.0-6-ca3f2b2b-SNAPSHOT"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"


### PR DESCRIPTION
Prepare for Lerna module updates

* `akka-entity-replication`
  * It requires us to update Akka.
* `lerna-app-library`

After the stable versions of above modules are released:
1. Use stable versions instead
2. Release a new version of this template