### PR TITLE
Update akka-entity-replication to 2.0.0+280-0352e28d-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Dependency Updates
 - Update *lerna-app-library* to 3.0.0-6-ca3f2b2b-SNAPSHOT from 3.0.0
-- Update *akka-entity-replication* to 2.0.0+111-c87ff6bc-SNAPSHOT from 2.0.0
+- Update *akka-entity-replication* to 2.0.0+280-0352e28d-SNAPSHOT from 2.0.0
 - Update *akka* to 2.6.17 from 2.6.12  
   *akka-entity-replication* recommends we use the same version of Akka.
 

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "2.0.0+111-c87ff6bc-SNAPSHOT"
+    val akkaEntityReplication    = "2.0.0+280-0352e28d-SNAPSHOT"
     val lerna                    = "3.0.0-6-ca3f2b2b-SNAPSHOT"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"


### PR DESCRIPTION
Update akka-entity-replication to the latest snapshot version (`2.0.0+280-0352e28d-SNAPSHOT`).