### PR TITLE
Release v2022.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [Unreleased]
+[Unreleased]: https://github.com/lerna-stack/lerna.g8/compare/main...develop
+
+
+## [v2022.3.0] - 2022-3-25
+[v2022.3.0]: https://github.com/lerna-stack/lerna.g8/compare/v2021.10.0...v2022.3.0
 
 ### Dependency Updates
 - Update *lerna-app-library* to 3.0.1 from 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Dependency Updates
 - Update *lerna-app-library* to 3.0.1 from 3.0.0
-- Update *akka-entity-replication* to 2.0.0+280-0352e28d-SNAPSHOT from 2.0.0
+- Update *akka-entity-replication* to 2.1.0 from 2.0.0
 - Update *akka* to 2.6.17 from 2.6.12  
   *akka-entity-replication* recommends we use the same version of Akka.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Dependency Updates
-- Update *lerna-app-library* to 3.0.0-6-ca3f2b2b-SNAPSHOT from 3.0.0
+- Update *lerna-app-library* to 3.0.1 from 3.0.0
 - Update *akka-entity-replication* to 2.0.0+280-0352e28d-SNAPSHOT from 2.0.0
 - Update *akka* to 2.6.17 from 2.6.12  
   *akka-entity-replication* recommends we use the same version of Akka.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(ScriptedPlugin)
   .settings(
-    name := "My Template Project",
+    name := "lerna.g8",
     test in Test := {
       val _ = (g8Test in Test).toTask("").value
     },

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -36,9 +36,6 @@ ThisBuild / fork in Test := true
 // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき紛らわしいため
 ThisBuild / outputStrategy := Some(StdoutOutput)
 
-// TODO Remove this snapshot repo after stable version release
-ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
-
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, JavaServerAppPackaging, RpmPlugin, SystemdPlugin)
   .aggregate(

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "2.0.0+280-0352e28d-SNAPSHOT"
+    val akkaEntityReplication    = "2.1.0"
     val lerna                    = "3.0.1"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val akkaEntityReplication    = "2.0.0+280-0352e28d-SNAPSHOT"
-    val lerna                    = "3.0.0-6-ca3f2b2b-SNAPSHOT"
+    val lerna                    = "3.0.1"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"


### PR DESCRIPTION
* Update lerna-app-library to 3.0.1
* Update akka-entity-replication to 2.1.0
* Set project name to `lerna.g8` (not affected to users)

TODO
* [ ] Merge branch `develop` into `main` (after this PR is merged)
* [ ] Create a new release `v2022.3.0` (after `develop` is merged into `main`)