### PR TITLE
Release v2022.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [Unreleased]: https://github.com/lerna-stack/lerna.g8/compare/main...develop
 
 
+## [v2022.12.0] - 2022-12-26
+[v2022.12.0]: https://github.com/lerna-stack/lerna.g8/compare/v2022.3.0...v2022.12.0
+
+### Dependency Updates
+- Update *akka-entity-replication* to 2.2.0 from 2.1.0
+
+
 ## [v2022.3.0] - 2022-3-25
 [v2022.3.0]: https://github.com/lerna-stack/lerna.g8/compare/v2021.10.0...v2022.3.0
 

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "2.1.0"
+    val akkaEntityReplication    = "2.2.0"
     val lerna                    = "3.0.1"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"


### PR DESCRIPTION
TODO:
* [x] update `akka-entity-replication` to v2.2.0
* [x] Remove Sonatype snapshots repo from resolvers
* [x] Revise the release date
* [ ] Merge `develop` into `main` after this PR is merged